### PR TITLE
fix: CJS build

### DIFF
--- a/dist/cjs/package.json
+++ b/dist/cjs/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}


### PR DESCRIPTION
This PR fixes the generated CommonJS build. The missing `package.json` was causing ERR_REQUIRE_ESM errors from code using CommonJS modules.